### PR TITLE
Added log folder, removed entry from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 docs/*
 examples/config.php
 utils/config.php
-log/*
+


### PR DESCRIPTION
By default enabling ``` Podio::$debug = true; ``` would throw errors, as there is no ``` log/podio.log ``` file. It would be good to add this by default. Also mention in the docs about giving the correct permission to the folder (log/podio.log) . 