### PR TITLE
Update PodioItemField.php

### DIFF
--- a/models/PodioItemField.php
+++ b/models/PodioItemField.php
@@ -343,7 +343,11 @@ class PodioQuestionItemField extends PodioItemField {
 class PodioCategoryItemField extends PodioItemField {
   public function humanized_value() {
     return join('; ', array_map(function($value){
-      return $value['value']['text'];
+      foreach($this->config['settings']['options'] AS $option){
+            if ($value['value']['id'] == $option['id']){
+                return $option['text'];
+            }
+        }
     }, $this->values));
   }
 }


### PR DESCRIPTION
If you set the value using set_value, PodioItemField will only store the option id, but humanized_value assumes that the option text is also part of the value. As of this change, the text will be looked up from the options array instead.