### PR TITLE
Corrected required declaration of PodioByLine.php

### DIFF
--- a/PodioAPI.php
+++ b/PodioAPI.php
@@ -20,7 +20,7 @@ require_once 'models/PodioApp.php';
 require_once 'models/PodioAppField.php';
 require_once 'models/PodioAppMarketShare.php';
 require_once 'models/PodioBatch.php';
-require_once 'models/PodioByline.php';
+require_once 'models/PodioByLine.php';
 require_once 'models/PodioCalendarEvent.php';
 require_once 'models/PodioCalendarMute.php';
 require_once 'models/PodioComment.php';


### PR DESCRIPTION
It used to have lower case l instead of L. That created problems on linux systems which are case sensitive.