### PR TITLE
Fix issue with set_value(null)

### DIFF
--- a/models/PodioItemField.php
+++ b/models/PodioItemField.php
@@ -381,7 +381,7 @@ class PodioDateItemField extends PodioItemField {
     $tz = new DateTimeZone('UTC');
     $values = parent::__get('values');
 
-    if ($name == 'values' && is_array($values)) {
+    if ($name == 'values' && is_array($values) && !empty($values)) {
 
       $start = DateTime::createFromFormat('Y-m-d H:i:s', $values[0]['start_date_utc'].' '.(!empty($values[0]['start_time_utc']) ? $values[0]['start_time_utc'] : '00:00:00'), $tz);
       if (!isset($values[0]['end_date_utc']) || ($values[0]['start_date_utc'] == $values[0]['end_date_utc'] && empty($values[0]['end_time_utc']))) {


### PR DESCRIPTION
The follow code fails with the error message: "Notice: Undefined offset: 0 in /Users/carlfredrikhero/Web/PHP/AdvancedWebform/vendor/podio/podio-php/models/PodioItemField.php on line 385"

```php
// authenticate here first

$date = new PodioDateItemField(array("external_id" => "date"));

$date->set_value(null);

$fields = new PodioItemFieldCollection(array(
  $date,
));

$item = new PodioItem(array(
    'app' => new PodioApp(123),
    'fields' => $fields,
));

$item->save();
```

I can't determine which, but one of the magic set methods sets the value to an empty array, adding !empty($values) solves the issue. There probably is a better way but I can't find it right now.

Here's the relevant stack trace:
#0 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItemField.php(386): Slim\Slim::handleErrors(8, 'Undefined offse...', '/var/vhosts/adv...', 386, Array)
#1 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItemField.php(403): PodioDateItemField->__get('values')
#2 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItemField.php(579): PodioDateItemField->__get('start')
#3 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItemField.php(46): PodioDateItemField->api_friendly_values()
#4 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/lib/PodioObject.php(318): PodioItemField->as_json(false)
#5 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItem.php(81): PodioObject->as_json(false)
#6 /var/vhosts/advancedwebform.com/vendor/podio/podio-php/models/PodioItem.php(59): PodioItem->as_json_without_readonly_fields()
#7 /var/vhosts/advancedwebform.com/vendor/elvenite/advanced-webform/src/AdvancedWebform.php(900): PodioItem->save()

So why do I try to set the value to a null value? Setting the value to null ensures that the value is actually empty, if I don't set the value, the field will be unchanged. This works for all other field types.