### PR TITLE
Remove undefined index for set_value(falsy value)

### DIFF
--- a/models/PodioItemField.php
+++ b/models/PodioItemField.php
@@ -272,7 +272,7 @@ class PodioLocationItemField extends PodioItemField {
    */
   public function __get($name) {
     $attribute = parent::__get($name);
-    if ($name == 'values' && is_array($attribute)) {
+    if ($name == 'values' && is_array($attribute) && !empty($attribute)) {
       return $attribute[0];
     }
     elseif ($name == 'text') {


### PR DESCRIPTION
If set_value is called with a falsy value (false, 0, null etc), $this->values gets an empty array.

But the __get assumes that there is at least one value (return $attribute[0] on line 276). This results in an "undefined index" error.

Adding a check for empty array fixes this.