### PR TITLE
Made the upload function compatible with PHP 5.6.

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -176,6 +176,7 @@ class Podio {
         curl_setopt(self::$ch, CURLOPT_CUSTOMREQUEST, self::POST);
         if (!empty($options['upload'])) {
           curl_setopt(self::$ch, CURLOPT_POST, TRUE);
+          curl_setopt(self::$ch, CURLOPT_SAFE_UPLOAD, FALSE);
           curl_setopt(self::$ch, CURLOPT_POSTFIELDS, $attributes);
           self::$headers['Content-type'] = 'multipart/form-data';
         }


### PR DESCRIPTION
The default value of CURLOPT_SAFE_UPLOAD was changed from FALSE to
TRUE in PHP 5.6, which broke the Podio file upload functionality.
This changes fixes it.