### PR TITLE
Fix security issue - verify TLS certificates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
   "require": {
     "php": ">=5.3.0"
   },
+  "suggest": {
+    "kdyby/curl-ca-bundle": "Improve security through providing current CA ROOT certificates bundle"
+  },
   "autoload": {
     "classmap": ["lib/", "models/"]
   }

--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -30,6 +30,11 @@ class Podio {
     curl_setopt(self::$ch, CURLOPT_HEADER, true);
     curl_setopt(self::$ch, CURLINFO_HEADER_OUT, true);
 
+    //Update CA root certificates - require: https://github.com/Kdyby/CurlCaBundle
+    if(class_exists('\\Kdyby\\CurlCaBundle\\CertificateHelper')) {
+      \Kdyby\CurlCaBundle\CertificateHelper::setCurlCaInfo(self::$ch);
+    }
+
     if ($options && !empty($options['curl_options'])) {
       curl_setopt_array(self::$ch, $options['curl_options']);
     }

--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -24,8 +24,8 @@ class Podio {
       'Accept' => 'application/json',
     );
     curl_setopt(self::$ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt(self::$ch, CURLOPT_SSL_VERIFYPEER, false);
-    curl_setopt(self::$ch, CURLOPT_SSL_VERIFYHOST, false);
+    curl_setopt(self::$ch, CURLOPT_SSL_VERIFYPEER, 1);
+    curl_setopt(self::$ch, CURLOPT_SSL_VERIFYHOST, 2);
     curl_setopt(self::$ch, CURLOPT_USERAGENT, 'Podio PHP Client/'.self::VERSION);
     curl_setopt(self::$ch, CURLOPT_HEADER, true);
     curl_setopt(self::$ch, CURLINFO_HEADER_OUT, true);

--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -223,6 +223,9 @@ class Podio {
 
     $response = new PodioResponse();
     $raw_response = curl_exec(self::$ch);
+    if($raw_response === false) {
+        throw new PodioConnectionError('Connection to Podio API failed: [' . curl_errno(self::$ch) . '] ' . curl_error(self::$ch), curl_errno(self::$ch));
+    }
     $raw_headers_size = curl_getinfo(self::$ch, CURLINFO_HEADER_SIZE);
     $response->body = substr($raw_response, $raw_headers_size);
     $response->status = curl_getinfo(self::$ch, CURLINFO_HTTP_CODE);

--- a/lib/PodioError.php
+++ b/lib/PodioError.php
@@ -41,4 +41,5 @@ class PodioServerError extends PodioError {}
 class PodioUnavailableError extends PodioError {}
 class PodioMissingRelationshipError extends PodioError {}
 
+class PodioConnectionError extends Exception {}
 class PodioDataIntegrityError extends Exception {}

--- a/lib/PodioError.php
+++ b/lib/PodioError.php
@@ -9,6 +9,7 @@ class PodioError extends Exception {
     $this->status = $status;
     $this->url = $url;
     $this->request = $this->body['request'];
+    parent::__construct(get_class($this), 1, null);
   }
 
   public function __toString() {


### PR DESCRIPTION
Communication encryption as MITM attack prevention is unnecessary without certificates verification.

This PR fixes:
* Fix cURL failure detection
* Close security by crt verification
* Optionally allow replace outdated system root crts bundle on webhosting with app-based bundle from @fprochazka.