### PR TITLE
session_manager passed as instance

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -40,17 +40,17 @@ class Podio {
       curl_setopt_array(self::$ch, $options['curl_options']);
     }
 
-      self::$session_manager = null;
-      if ($options && !empty($options['session_manager'])) {
-          if(is_string($options['session_manager']) && class_exists($options['session_manager'])) {
-              self::$session_manager = new $options['session_manager'];
-          } else if (is_object($options['session_manager']) && method_exists($options['session_manager'], 'get') && method_exists($options['session_manager'], 'get')) {
-              self::$session_manager = $options['session_manager'];
-          }
-          if(self::$session_manager) {
-              self::$oauth = self::$session_manager->get();
-          }
+    self::$session_manager = null;
+    if ($options && !empty($options['session_manager'])) {
+      if (is_string($options['session_manager']) && class_exists($options['session_manager'])) {
+        self::$session_manager = new $options['session_manager'];
+      } else if (is_object($options['session_manager']) && method_exists($options['session_manager'], 'get') && method_exists($options['session_manager'], 'get')) {
+        self::$session_manager = $options['session_manager'];
       }
+      if (self::$session_manager) {
+        self::$oauth = self::$session_manager->get();
+      }
+    }
 
     // Register shutdown function for debugging and session management
     register_shutdown_function('Podio::shutdown');

--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -40,11 +40,17 @@ class Podio {
       curl_setopt_array(self::$ch, $options['curl_options']);
     }
 
-    self::$session_manager = null;
-    if ($options && !empty($options['session_manager']) && class_exists($options['session_manager'])) {
-      self::$session_manager = new $options['session_manager'];
-      self::$oauth = self::$session_manager->get();
-    }
+      self::$session_manager = null;
+      if ($options && !empty($options['session_manager'])) {
+          if(is_string($options['session_manager']) && class_exists($options['session_manager'])) {
+              self::$session_manager = new $options['session_manager'];
+          } else if (is_object($options['session_manager']) && method_exists($options['session_manager'], 'get') && method_exists($options['session_manager'], 'get')) {
+              self::$session_manager = $options['session_manager'];
+          }
+          if(self::$session_manager) {
+              self::$oauth = self::$session_manager->get();
+          }
+      }
 
     // Register shutdown function for debugging and session management
     register_shutdown_function('Podio::shutdown');


### PR DESCRIPTION
Hi,
this allows to pass a concrete session_manager instance (additionally to the current passing of a class name). So the session manager can be setup (e.g. for the current user) beforehand and does not need context knowledge.
greets, Daniel