### PR TITLE
Added Label to PodioAppField Class

### DIFF
--- a/models/PodioAppField.php
+++ b/models/PodioAppField.php
@@ -9,6 +9,7 @@ class PodioAppField extends PodioObject {
     $this->property('external_id', 'string');
     $this->property('config', 'hash');
     $this->property('status', 'string');
+    $this->property('label', 'string');
 
     $this->init($attributes);
   }


### PR DESCRIPTION
Added Label to PodioAppField Class (see https://help.podio.com/hc/communities/public/questions/204525777-Missing-required-properties-when-updating-PodioAppField?locale=en-us)