### PR TITLE
Add Podio::setup() to Hello World

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,6 +25,7 @@ To get started right away, use app authentication to work on a single Podio app.
 {% highlight php startinline %}
 require_once '/path/to/podio-php/PodioAPI.php';
 
+Podio::setup($client_id, $client_secret);
 Podio::authenticate_with_app($app_id, $app_token);
 $items = PodioItem::filter($app_id);
 


### PR DESCRIPTION
The Authentication pages states:
>Before you can do anything you must setup the API client using your Podio API key. Head over to Podio to generate a client_id and client_secret before continuing.

So before we can authenticate in our Hello World example, we must first do `Podio::setup()`