### PR TITLE
Both get and set functions should be checked in a session manager object

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -44,7 +44,7 @@ class Podio {
     if ($options && !empty($options['session_manager'])) {
       if (is_string($options['session_manager']) && class_exists($options['session_manager'])) {
         self::$session_manager = new $options['session_manager'];
-      } else if (is_object($options['session_manager']) && method_exists($options['session_manager'], 'get') && method_exists($options['session_manager'], 'get')) {
+      } else if (is_object($options['session_manager']) && method_exists($options['session_manager'], 'get') && method_exists($options['session_manager'], 'set')) {
         self::$session_manager = $options['session_manager'];
       }
       if (self::$session_manager) {


### PR DESCRIPTION
When a session manager object is passed, both get and set methods should be present. Probably due to a typo there was checked for the get function twice.