### PR TITLE
Fixed __get('values') for PodioCalculationItemField when referencing …

### DIFF
--- a/models/PodioItemField.php
+++ b/models/PodioItemField.php
@@ -1122,7 +1122,7 @@ class PodioCalculationItemField extends PodioItemField {
   public function __get($name) {
     $attribute = parent::__get($name);
     if ($name == 'values' && $attribute) {
-      return $attribute[0]['value'];
+      return (isset($attribute[0]['value'])) ? $attribute[0]['value'] : $attribute;
     }
     return $attribute;
   }

--- a/models/PodioItemField.php
+++ b/models/PodioItemField.php
@@ -1122,7 +1122,7 @@ class PodioCalculationItemField extends PodioItemField {
   public function __get($name) {
     $attribute = parent::__get($name);
     if ($name == 'values' && $attribute) {
-      return (isset($attribute[0]['value'])) ? $attribute[0]['value'] : $attribute;
+      return (isset($attribute[0]['value'])) ? $attribute[0]['value'] : $attribute[0];
     }
     return $attribute;
   }


### PR DESCRIPTION
This PR fixes __get('values') on a PodioCalculationItemField when referencing a date field.  See #110 
